### PR TITLE
Fix a warning found by clang.

### DIFF
--- a/lm/vocab.hh
+++ b/lm/vocab.hh
@@ -24,7 +24,7 @@ uint64_t HashForVocab(const char *str, std::size_t len);
 inline uint64_t HashForVocab(const StringPiece &str) {
   return HashForVocab(str.data(), str.length());
 }
-class ProbingVocabularyHeader;
+struct ProbingVocabularyHeader;
 } // namespace detail
 
 class WriteWordsWrapper : public EnumerateVocab {


### PR DESCRIPTION
'ProbingVocabularyHeader' defined as a struct here but previously
declared as a class.
