### PR TITLE
Bug fix: limit _read() size to 2GB instead of 4GB.

### DIFF
--- a/util/file.cc
+++ b/util/file.cc
@@ -129,7 +129,7 @@ std::size_t GuardLarge(std::size_t size) {
   // The following operating systems have broken read/write/pread/pwrite that
   // only supports up to 2^31.
 #if defined(_WIN32) || defined(_WIN64) || defined(__APPLE__) || defined(OS_ANDROID) || defined(__MINGW32__)
-  return std::min(static_cast<std::size_t>(static_cast<unsigned>(-1)), size);
+  return std::min(static_cast<std::size_t>(INT_MAX), size);
 #else
   return size;
 #endif


### PR DESCRIPTION
The maximum number of bytes read was incorrectly set to 4GB (2^32)
instead of 2GB (2^31).

The result was that language models over 2GB failed to load in memory on
Windows.
