### PR TITLE
CMake Windows Build Cleanup 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,11 +9,26 @@ if (FORCE_STATIC)
   #presumably overkill, is there a better way?
   #http://cmake.3232098.n2.nabble.com/Howto-compile-static-executable-td5580269.html
   set(Boost_USE_STATIC_LIBS ON)
-  set(CMAKE_FIND_LIBRARY_SUFFIXES ".a")
   set_property(GLOBAL PROPERTY LINK_SEARCH_START_STATIC ON)
   set_property(GLOBAL PROPERTY LINK_SEARCH_END_STATIC ON)
   set(BUILD_SHARED_LIBRARIES OFF)
-  set(CMAKE_EXE_LINKER_FLAGS "-static-libgcc -static-libstdc++ -static")
+  if (MSVC)
+	set(flag_vars
+	  CMAKE_CXX_FLAGS CMAKE_CXX_FLAGS_DEBUG CMAKE_CXX_FLAGS_RELEASE
+	  CMAKE_CXX_FLAGS_MINSIZEREL CMAKE_CXX_FLAGS_RELWITHDEBINFO
+	  CMAKE_C_FLAGS CMAKE_C_FLAGS_DEBUG CMAKE_C_FLAGS_RELEASE
+	  CMAKE_C_FLAGS_MINSIZEREL CMAKE_C_FLAGS_RELWITHDEBINFO)
+	  foreach(flag_var ${flag_vars})
+	    if(${flag_var} MATCHES "/MD")
+	      string(REGEX REPLACE "/MD" "/MT" ${flag_var} "${${flag_var}}")
+	    endif(${flag_var} MATCHES "/MD")
+	  endforeach(flag_var)
+  else (MSVC)
+    if (NOT CMAKE_C_COMPILER_ID MATCHES "*Clang")
+      set(CMAKE_EXE_LINKER_FLAGS "-static-libgcc -static-libstdc++ -static")
+    endif ()
+  set(CMAKE_FIND_LIBRARY_SUFFIXES ".a")
+  endif ()
   #Annoyingly the exectuables say "File not found" unless these are set
   set(CMAKE_EXE_LINK_DYNAMIC_C_FLAGS)
   set(CMAKE_EXE_LINK_DYNAMIC_CXX_FLAGS)
@@ -40,6 +55,11 @@ enable_testing()
 # Add our CMake helper functions
 include(cmake/KenLMFunctions.cmake)
 
+if(MSVC)
+  set(CMAKE_C_FLAGS "${CMAKE_CXX_FLAGS} /w34716")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /w34716")
+endif()
+
 # And our helper modules
 list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake/modules)
 
@@ -49,8 +69,9 @@ find_package(Boost 1.36.0 REQUIRED COMPONENTS
   system
   thread
   unit_test_framework
+  date_time
+  chrono
 )
-
 
 # Define where include files live
 include_directories(

--- a/lm/CMakeLists.txt
+++ b/lm/CMakeLists.txt
@@ -30,8 +30,12 @@ set(KENLM_LM_SOURCE
 #
 add_subdirectory(common)
 
+if (NOT MSVC)
+	set(THREADS pthread)
+endif()
+
 add_library(kenlm ${KENLM_LM_SOURCE} ${KENLM_LM_COMMON_SOURCE})
-target_link_libraries(kenlm kenlm_util ${Boost_LIBRARIES} pthread)
+target_link_libraries(kenlm kenlm_util ${Boost_LIBRARIES} ${THREADS})
 
 set(KENLM_MAX_ORDER 6 CACHE STRING "Maximum supported ngram order")
 target_compile_definitions(kenlm PUBLIC -DKENLM_MAX_ORDER=${KENLM_MAX_ORDER})
@@ -49,7 +53,7 @@ set(EXE_LIST
   kenlm_benchmark
 )
 
-set(LM_LIBS kenlm kenlm_util ${Boost_LIBRARIES} pthread)
+set(LM_LIBS kenlm kenlm_util ${Boost_LIBRARIES} ${THREADS})
 
 AddExes(EXES ${EXE_LIST}
         LIBRARIES ${LM_LIBS})

--- a/lm/builder/CMakeLists.txt
+++ b/lm/builder/CMakeLists.txt
@@ -28,8 +28,12 @@ set(KENLM_BUILDER_SOURCE
 #
 add_library(kenlm_builder ${KENLM_BUILDER_SOURCE})
 
+if (NOT MSVC)
+	set(THREADS pthread)
+endif()
+
 AddExes(EXES lmplz
-        LIBRARIES kenlm_builder kenlm kenlm_util ${Boost_LIBRARIES} pthread)
+        LIBRARIES kenlm_builder kenlm kenlm_util ${Boost_LIBRARIES} ${THREADS})
 
 if(BUILD_TESTING)
 
@@ -40,5 +44,5 @@ if(BUILD_TESTING)
   )
 
   AddTests(TESTS ${KENLM_BOOST_TESTS_LIST}
-           LIBRARIES kenlm_builder kenlm kenlm_util ${Boost_LIBRARIES} pthread)
+           LIBRARIES kenlm_builder kenlm kenlm_util ${Boost_LIBRARIES} ${THREADS})
 endif()

--- a/lm/filter/CMakeLists.txt
+++ b/lm/filter/CMakeLists.txt
@@ -17,7 +17,6 @@ set(KENLM_FILTER_SOURCE
 		${CMAKE_CURRENT_SOURCE_DIR}/vocab.cc
 	)
 
-
 # Group these objects together for later use.
 #
 # Given add_library(foo OBJECT ${my_foo_sources}),
@@ -25,6 +24,10 @@ set(KENLM_FILTER_SOURCE
 #
 add_library(kenlm_filter ${KENLM_FILTER_SOURCE})
 
+if (NOT MSVC)
+	set(THREADS pthread)
+endif()
+
 AddExes(EXES filter phrase_table_vocab
-        LIBRARIES kenlm_filter kenlm kenlm_util ${Boost_LIBRARIES} pthread)
+        LIBRARIES kenlm_filter kenlm kenlm_util ${Boost_LIBRARIES} ${THREADS})
 

--- a/lm/interpolate/CMakeLists.txt
+++ b/lm/interpolate/CMakeLists.txt
@@ -30,9 +30,13 @@ if(EIGEN3_FOUND)
     set(KENLM_INTERPOLATE_EXES
         interpolate
         streaming_example)
+		
+	if (NOT MSVC)
+	  set(THREADS pthread)
+	endif()
   
       set(KENLM_INTERPOLATE_LIBS
-        kenlm_interpolate kenlm kenlm_util ${Boost_LIBRARIES} pthread)
+        kenlm_interpolate kenlm kenlm_util ${Boost_LIBRARIES} ${THREADS})
   
     AddExes(EXES ${KENLM_INTERPOLATE_EXES}
             LIBRARIES ${KENLM_INTERPOLATE_LIBS})

--- a/util/CMakeLists.txt
+++ b/util/CMakeLists.txt
@@ -33,21 +33,21 @@ find_package(ZLIB)
 if (ZLIB_FOUND)
   set(READ_COMPRESSED_FLAGS "${READ_COMPRESSED_FLAGS} -DHAVE_ZLIB")
   set(READ_COMPRESSED_LIBS ${READ_COMPRESSED_LIBS} ${ZLIB_LIBRARIES})
-  include_directories(${ZLIB_INCLUDE_DIRECTORIES})
+  include_directories(${ZLIB_INCLUDE_DIR})
 endif()
 
 find_package(BZip2)
 if (BZIP2_FOUND)
   set(READ_COMPRESSED_FLAGS "${READ_COMPRESSED_FLAGS} -DHAVE_BZLIB")
   set(READ_COMPRESSED_LIBS ${READ_COMPRESSED_LIBS} ${BZIP2_LIBRARIES})
-  include_directories(${BZIP2_INCLUDE_DIRECTORIES})
+  include_directories(${BZIP2_INCLUDE_DIR})
 endif()
 
 find_package(LibLZMA)
 if (LIBLZMA_FOUND)
   set(READ_COMPRESSED_FLAGS "${READ_COMPRESSED_FLAGS} -DHAVE_XZLIB")
   set(READ_COMPRESSED_LIBS ${READ_COMPRESSED_LIBS} ${LIBLZMA_LIBRARIES})
-  include_directories(${LIBLZMA_INCLUDE_DIRECTORIES})
+  include_directories(${LIBLZMA_INCLUDE_DIRS})
 endif()
 set_source_files_properties(read_compressed.cc PROPERTIES COMPILE_FLAGS ${READ_COMPRESSED_FLAGS})
 set_source_files_properties(read_compressed_test.cc PROPERTIES COMPILE_FLAGS ${READ_COMPRESSED_FLAGS})
@@ -63,12 +63,16 @@ else()
   set(TIMER_LINK)
 endif()
 
+if (NOT MSVC)
+	set(THREADS pthread)
+endif()
+
 # Group these objects together for later use.
 add_library(kenlm_util ${KENLM_UTIL_DOUBLECONVERSION_SOURCE} ${KENLM_UTIL_STREAM_SOURCE} ${KENLM_UTIL_SOURCE})
-target_link_libraries(kenlm_util ${Boost_LIBRARIES} ${READ_COMPRESSED_LIBS} pthread ${TIMER_LINK})
+target_link_libraries(kenlm_util ${Boost_LIBRARIES} ${READ_COMPRESSED_LIBS} ${THREADS} ${TIMER_LINK})
 
 AddExes(EXES probing_hash_table_benchmark
-        LIBRARIES kenlm_util ${Boost_LIBRARIES} pthread)
+        LIBRARIES kenlm_util ${Boost_LIBRARIES} ${THREADS})
 
 # Only compile and run unit tests if tests should be run
 if(BUILD_TESTING)
@@ -87,10 +91,10 @@ if(BUILD_TESTING)
   )
 
   AddTests(TESTS ${KENLM_BOOST_TESTS_LIST}
-           LIBRARIES kenlm_util ${Boost_LIBRARIES} pthread)
+           LIBRARIES kenlm_util ${Boost_LIBRARIES} ${THREADS})
 
   # file_piece_test requires an extra command line parameter
   KenLMAddTest(TEST file_piece_test
-               LIBRARIES kenlm_util ${Boost_LIBRARIES} pthread
+               LIBRARIES kenlm_util ${Boost_LIBRARIES} ${THREADS}
                TEST_ARGS ${CMAKE_CURRENT_SOURCE_DIR}/file_piece.cc)
 endif()


### PR DESCRIPTION
I've done the following to cleanup the build process on MSVC (Visual Studio 2013): 

* Suppress C4716
* Do not include pthread if on Windows/MSVC
* Use /MT (statically linked MSVCRT) when FORCE_STATIC is enabled
* Add additional Boost libraries as required for the build
* Using CMake module-defined parameters for compression libraries (ZLIB, BZIP2, LZMA)

We were targeting only a subset of the tools this project builds, so this change will probably not fix all Windows build issues across all targets. It resulted in a successful build of lmplz and its dependencies.