### PR TITLE
Fix compilation error (isnan) with g++ 6.1.1

### DIFF
--- a/lm/interpolate/tune_instances_test.cc
+++ b/lm/interpolate/tune_instances_test.cc
@@ -12,6 +12,8 @@
 
 #include <vector>
 
+#include <math.h>
+
 namespace lm { namespace interpolate { namespace {
 
 BOOST_AUTO_TEST_CASE(Toy) {


### PR DESCRIPTION
Hi!

I have a compilation error when compiling the "tune_instances_test" unit test, only when using g++ 6.1.1 (it works with older g++ versions).

`
In file included from /usr/include/boost/test/test_tools.hpp:45:0,
                 from /usr/include/boost/test/unit_test.hpp:18,
                 from /home/vincent/dev/kenlm/lm/interpolate/tune_instances_test.cc:11:
/home/vincent/dev/kenlm/lm/interpolate/tune_instances_test.cc: In member function ‘void lm::interpolate::{anonymous}::Toy::test_method()’:
/home/vincent/dev/kenlm/lm/interpolate/tune_instances_test.cc:55:39: error: ‘isnan’ was not declared in this scope
   BOOST_CHECK(!isnan(ln_unigrams(1, 0)));
`

It seems that, as isnan() is only defined in C++11, the compiler is not able to find the required function in the "cmath" header.

You can fix the problem by including the raw "math.h" header, just like in this commit: https://github.com/kpu/kenlm/commit/15553b82d0cbea710bdadaeb84fbf4684f7806a1

One other solution would be to make the code C++11 only, but losing C++98 support may not be a good idea :-).

WIth the pull request, all the unit tests run successfully:

`
~/dev/kenlm/build$ ctest
Test project /home/vincent/dev/kenlm/build
[...]
      Start 27: tune_instances_test
27/28 Test #27: tune_instances_test ..............   Passed    0.33 sec
[...]
100% tests passed, 0 tests failed out of 28
`

Regards and thanks for KenLM ;-),

Vincent