### PR TITLE
Compare all ngrams for equality on the left side of a state.

### DIFF
--- a/lm/state.hh
+++ b/lm/state.hh
@@ -55,9 +55,8 @@ inline uint64_t hash_value(const State &state, uint64_t seed = 0) {
 
 struct Left {
   bool operator==(const Left &other) const {
-    return
-      length == other.length &&
-      (!length || (pointers[length - 1] == other.pointers[length - 1] && full == other.full));
+    return length == other.length && full == other.full &&
+           !memcmp(pointers, other.pointers, sizeof(uint64_t) * length);
   }
 
   int Compare(const Left &other) const {


### PR DESCRIPTION
This PR is related to rare issue seen in Joshua.  The best place to see the full discussion of this issue would be here https://github.com/apache/incubator-joshua/pull/48

The summary is that hash collisions between state objects can sometimes cause crashing in Joshua.  Joshua has a mapping between hashes of states and pointers to those states in a pool.  If a collision happens between two instances of kenlm, which share states, we potentially return a state that has a unigram word id that is out-of-range for whichever model has a smaller vocabulary.

Part of this fix actually applies to the Joshua project, and is in the link above.  However, to resolve the collisions we have to check equality of state objects.  The currently equality check only looks at the length-1 position in the pointers array.  I'm assuming this is for performance reasons, and that during left to right phrase-based decoding this is the only significant position that needs to be compared? Unfortunately, this means in Joshua if we have two states whose hashes collide, and they happen to have the same ngram in position length-1, and the state in our pool has an out-of-range wordid in position 0 we crash.

I'm hoping this PR fixes the issue.  I've tested it with previously deterministically failing input and it now translates without crashing Joshua.  I've run the tests included in Nightly and they seem to still all pass.  Joshua tests (which depend on correct KenLM functionality) are also still passing. https://travis-ci.org/apache/incubator-joshua/jobs/156215418

I had one more quick question related to this change.  Should we be comparing pointers here, or their actual values?  My understanding is that at index 0 we'll just have a word id and should directly compare values.  For the other elements of the pointer array should we be comparing the dereferenced values?