### PR TITLE
Rename Model to LanguageModel

### DIFF
--- a/python/example.py
+++ b/python/example.py
@@ -3,7 +3,7 @@ import os
 import kenlm
 
 LM = os.path.join(os.path.dirname(__file__), '..', 'lm', 'test.arpa')
-model = kenlm.Model(LM)
+model = kenlm.LanguageModel(LM)
 print('{0}-gram model'.format(model.order))
 
 sentence = 'language modeling is fun .'


### PR DESCRIPTION
There is no `Model` in python interface:

```
>>> model = kenlm.Model(LM)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: 'module' object has no attribute 'Model'
```
Check the python interface `help(kenlm)` and we obtain:

```
Help on module kenlm:

NAME
    kenlm

FILE
    /workspace/jialinwu/anaconda2/lib/python2.7/site-packages/kenlm.so

CLASSES
    __builtin__.object
        LanguageModel

    class LanguageModel(__builtin__.object)
     |  Methods defined here:
     |
     |  __contains__(...)
     |      x.__contains__(y) <==> y in x
     |
     |  __init__(...)
     |      x.__init__(...) initializes x; see help(type(x)) for signature
     |
     |  __reduce__(...)
     |
     |  __repr__(...)
     |      x.__repr__() <==> repr(x)
     |
     |  full_scores(...)
     |
     |  score(...)
     |
     |  ----------------------------------------------------------------------
     |  Data descriptors defined here:
     |
     |  order
     |
     |  path
     |
     |  ----------------------------------------------------------------------
     |  Data and other attributes defined here:
     |
     |  __new__ = <built-in method __new__ of type object>
     |      T.__new__(S, ...) -> a new object with type S, a subtype of T

DATA
    __test__ = {}
```
and we can further verify the change like follows:

```
>>> a = kenlm.LanguageModel(LM)
Loading the LM will be faster if you build a binary file.
Reading /h1/jialinwu/hzy/fp-greg/text.arpa
----5---10---15---20---25---30---35---40---45---50---55---60---65---70---75---80---85---90---95--100
****************************************************************************************************
>>> print('{0}-gram model'.format(a.order))
5-gram model
```