### PR TITLE
Guard against missing __GNUC_PREREQ

### DIFF
--- a/util/file.cc
+++ b/util/file.cc
@@ -540,7 +540,7 @@ std::string DefaultTempDirectory() {
   const char *const vars[] = {"TMPDIR", "TMP", "TEMPDIR", "TEMP", 0};
   for (int i=0; vars[i]; ++i) {
     char *val =
-#if defined(_GNU_SOURCE)
+#if defined(_GNU_SOURCE) && defined(__GLIBC_PREREQ)
 #if __GLIBC_PREREQ(2,17)
       secure_getenv
 #else // __GLIBC_PREREQ


### PR DESCRIPTION
The C header files for musl (used in e.g. Alpine Linux) define `_GNU_SOURCE` but not `__GLIBC_PREREQ`, making the line
```
#if __GLIBC_PREREQ(2,17)
```
a syntax error:
```
    util/file.cc:544:19: error: missing binary operator before token "("
     #if __GLIBC_PREREQ(2,17)
                       ^
    error: command 'gcc' failed with exit status 1
```

cf:

https://github.com/leo-yuriev/ReOpenLDAP/issues/123
http://www.openwall.com/lists/musl/2012/10/20/10

This wraps the use of `__GLIBC_PREREQ` in a `defined()` guard.