### PR TITLE
Document Ubuntu build dependencies

### DIFF
--- a/BUILDING
+++ b/BUILDING
@@ -16,3 +16,6 @@ Windows:
 OSX:
   Missing dependencies can be remedied with brew.
   brew install cmake boost eigen
+
+Debian/Ubuntu:
+  sudo apt install libeigen3-dev build-essential libboost-system-dev libboost-thread-dev libboost-program-options-dev libboost-test-dev cmake zlib1g-dev libbz2-dev liblzma-dev

--- a/BUILDING
+++ b/BUILDING
@@ -18,4 +18,4 @@ OSX:
   brew install cmake boost eigen
 
 Debian/Ubuntu:
-  sudo apt install libeigen3-dev build-essential libboost-system-dev libboost-thread-dev libboost-program-options-dev libboost-test-dev cmake zlib1g-dev libbz2-dev liblzma-dev
+  sudo apt install build-essential cmake libboost-system-dev libboost-thread-dev libboost-program-options-dev libboost-test-dev libeigen3-dev zlib1g-dev libbz2-dev liblzma-dev

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ I do development in master on https://github.com/kpu/kenlm/.  Normally, it works
 The website https://kheafield.com/code/kenlm/ has more documentation.  If you're a decoder developer, please download the latest version from there instead of copying from another decoder.
 
 ## Compiling
-Use cmake, see [BUILDING](BUILDING) for more detail.
+Use cmake, see [BUILDING](BUILDING) for build dependencies and more detail.
 ```bash
 mkdir -p build
 cd build


### PR DESCRIPTION
List the exact Ubuntu packages that contain the build dependencies.

Tested on Ubuntu 18.04 LTS for desktop and Raspian stretch on Rasp Pi.