### PR TITLE
Fix bit packing and quantize on big endian.

### DIFF
--- a/lm/quantize.hh
+++ b/lm/quantize.hh
@@ -168,8 +168,8 @@ class SeparatelyQuantize {
         float Rest() const { return Prob(); }
 
         void Write(float prob, float backoff) const {
-          util::WriteInt57(address_.base, address_.offset, ProbBins().Bits() + BackoffBins().Bits(),
-              (ProbBins().EncodeProb(prob) << BackoffBins().Bits()) | BackoffBins().EncodeBackoff(backoff));
+          util::WriteInt25(address_.base, address_.offset + BackoffBins().Bits(), ProbBins().Bits(), ProbBins().EncodeProb(prob));
+          util::WriteInt25(address_.base, address_.offset, BackoffBins().Bits(), BackoffBins().EncodeBackoff(backoff));
         }
 
       private:

--- a/util/bit_packing.hh
+++ b/util/bit_packing.hh
@@ -37,9 +37,15 @@ namespace util {
 inline uint8_t BitPackShift(uint8_t bit, uint8_t /*length*/) {
   return bit;
 }
+inline uint8_t BitPackShift32(uint8_t bit, uint8_t /*length*/) {
+  return bit;
+}
 #elif BYTE_ORDER == BIG_ENDIAN
 inline uint8_t BitPackShift(uint8_t bit, uint8_t length) {
   return 64 - length - bit;
+}
+inline uint8_t BitPackShift32(uint8_t bit, uint8_t length) {
+  return 32 - length - bit;
 }
 #else
 #error "Bit packing code isn't written for your byte order."
@@ -85,9 +91,9 @@ inline uint32_t ReadInt25(const void *base, uint64_t bit_off, uint8_t length, ui
   const uint8_t *base_off = reinterpret_cast<const uint8_t*>(base) + (bit_off >> 3);
   uint32_t value32;
   memcpy(&value32, base_off, sizeof(value32));
-  return (value32 >> BitPackShift(bit_off & 7, length)) & mask;
+  return (value32 >> BitPackShift32(bit_off & 7, length)) & mask;
 #else
-  return (*reinterpret_cast<const uint32_t*>(reinterpret_cast<const uint8_t*>(base) + (bit_off >> 3)) >> BitPackShift(bit_off & 7, length)) & mask;
+  return (*reinterpret_cast<const uint32_t*>(reinterpret_cast<const uint8_t*>(base) + (bit_off >> 3)) >> BitPackShift32(bit_off & 7, length)) & mask;
 #endif
 }
 
@@ -96,11 +102,11 @@ inline void WriteInt25(void *base, uint64_t bit_off, uint8_t length, uint32_t va
   uint8_t *base_off = reinterpret_cast<uint8_t*>(base) + (bit_off >> 3);
   uint32_t value32;
   memcpy(&value32, base_off, sizeof(value32));
-  value32 |= (value << BitPackShift(bit_off & 7, length));
+  value32 |= (value << BitPackShift32(bit_off & 7, length));
   memcpy(base_off, &value32, sizeof(value32));
 #else
   *reinterpret_cast<uint32_t*>(reinterpret_cast<uint8_t*>(base) + (bit_off >> 3)) |=
-    (value << BitPackShift(bit_off & 7, length));
+    (value << BitPackShift32(bit_off & 7, length));
 #endif
 }
 


### PR DESCRIPTION
1. BitPackShift() doesn't return the right value on big endian for
   {Read,Write}Int25. Consecutive25 would just fail on big endian.
   The fix is to round it to 32 instead 64.

2. Using a WriteInt57 and Two ReadInt25 to read the combined integer value
   won't simply work on big endian. The fix just simply replace the
   WriteInt57 with two ReadInt25 for MiddlePointer.