### PR TITLE
Fix Quantize bit packing on big endian.

### DIFF
--- a/lm/quantize.hh
+++ b/lm/quantize.hh
@@ -169,15 +169,14 @@ class SeparatelyQuantize {
 
         void Write(float prob, float backoff) const {
           uint64_t prob_encoded = ProbBins().EncodeProb(prob);
-	  uint64_t backoff_encoded = BackoffBins().EncodeBackoff(backoff);
+          uint64_t backoff_encoded = BackoffBins().EncodeBackoff(backoff);
 #if BYTE_ORDER == LITTLE_ENDIAN
-	  prob_encoded
+          prob_encoded <<= BackoffBins().Bits();
 #elif BYTE_ORDER == BIG_ENDIAN
-          backoff_encoded
+          backoff_encoded <<= ProbBins().Bits();
 #endif
-		  <<= BackoffBins().Bits();
           util::WriteInt57(address_.base, address_.offset, ProbBins().Bits() + BackoffBins().Bits(),
-			   prob_encoded | backoff_encoded);
+                           prob_encoded | backoff_encoded);
         }
 
       private:


### PR DESCRIPTION
The bit shifted need to be the length of the one on lower bits.