### PR TITLE
Second mac os change proposal. clock_gettime is supported since 10.12

### DIFF
--- a/util/CMakeLists.txt
+++ b/util/CMakeLists.txt
@@ -63,8 +63,18 @@ endif()
 add_subdirectory(double-conversion)
 add_subdirectory(stream)
 
-if(UNIX AND NOT APPLE AND NOT ANDROID)
-  set(RT rt)
+if(UNIX)
+  include(CheckLibraryExists)
+  check_library_exists(rt clock_gettime "clock_gettime from librt" HAVE_CLOCKGETTIME_RT)
+  if (HAVE_CLOCKGETTIME_RT)
+    set(RT rt)
+  else()
+    check_library_exists(c clock_gettime "clock_gettime from the libc" HAVE_CLOCKGETTIME)
+  endif()
+
+  if (HAVE_CLOCKGETTIME_RT OR HAVE_CLOCKGETTIME)
+    add_definitions(-DHAVE_CLOCKGETTIME)
+  endif()
 endif()
 
 # Group these objects together for later use.

--- a/util/usage.cc
+++ b/util/usage.cc
@@ -171,16 +171,16 @@ double ThreadTime() {
   // GetThreadTimes() reports in units of 100 nanoseconds, i.e. ten-millionths
   // of a second.
   return ticks / (10 * 1000 * 1000);
+#elif defined(HAVE_CLOCKGETTIME)
+  struct timespec usage;
+  UTIL_THROW_IF(clock_gettime(CLOCK_THREAD_CPUTIME_ID, &usage), ErrnoException, "clock_gettime failed?!");
+  return DoubleSec(usage);
 #elif defined(__MACH__) || defined(__APPLE__)
   struct task_basic_info t_info;
   mach_msg_type_number_t t_info_count = TASK_BASIC_INFO_COUNT;  
   task_info(mach_task_self(), TASK_BASIC_INFO, (task_info_t)&t_info, &t_info_count);
   
   return 0.0;
-#else
-  struct timespec usage;
-  UTIL_THROW_IF(clock_gettime(CLOCK_THREAD_CPUTIME_ID, &usage), ErrnoException, "clock_gettime failed?!"); 
-  return DoubleSec(usage);
 #endif
 }
 


### PR DESCRIPTION
release thus proposing to detect at "configure" time its availability
 whether it comes from libc or librt instead.