### PR TITLE
Modernize CMake install

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -111,3 +111,32 @@ if(ENABLE_PYTHON)
   add_subdirectory(python)
 endif()
 
+# Asset installation
+install(
+  TARGETS kenlm kenlm_util
+  EXPORT kenlmTargets
+  RUNTIME DESTINATION bin
+  LIBRARY DESTINATION lib
+  ARCHIVE DESTINATION lib
+)
+
+install(EXPORT kenlmTargets
+  FILE kenlmTargets.cmake
+  NAMESPACE kenlm::
+  DESTINATION share/kenlm/cmake
+)
+
+# Config
+include(CMakePackageConfigHelpers)
+# generate the config file that is includes the exports
+configure_package_config_file(${PROJECT_SOURCE_DIR}/cmake/kenlmConfig.cmake.in
+  "${CMAKE_CURRENT_BINARY_DIR}/kenlmConfig.cmake"
+  INSTALL_DESTINATION share/kenlm/cmake
+  NO_SET_AND_CHECK_MACRO
+  NO_CHECK_REQUIRED_COMPONENTS_MACRO
+  )
+# install the configuration file
+install(FILES
+  ${CMAKE_CURRENT_BINARY_DIR}/kenlmConfig.cmake
+  DESTINATION share/kenlm/cmake
+  )

--- a/cmake/kenlmConfig.cmake.in
+++ b/cmake/kenlmConfig.cmake.in
@@ -1,0 +1,11 @@
+@PACKAGE_INIT@
+
+include(CMakeFindDependencyMacro)
+
+find_dependency(Boost)
+find_dependency(Threads)
+find_dependency(ZLIB)
+find_dependency(BZip2)
+find_dependency(LibLZMA)
+
+include("${CMAKE_CURRENT_LIST_DIR}/kenlmTargets.cmake")

--- a/lm/CMakeLists.txt
+++ b/lm/CMakeLists.txt
@@ -32,16 +32,10 @@ add_subdirectory(common)
 
 add_library(kenlm ${KENLM_LM_SOURCE} ${KENLM_LM_COMMON_SOURCE})
 set_target_properties(kenlm PROPERTIES POSITION_INDEPENDENT_CODE ON)
-target_link_libraries(kenlm PUBLIC kenlm_util ${Boost_LIBRARIES} Threads::Threads)
+target_link_libraries(kenlm PUBLIC kenlm_util Threads::Threads)
 
 set(KENLM_MAX_ORDER 6 CACHE STRING "Maximum supported ngram order")
 target_compile_definitions(kenlm PUBLIC -DKENLM_MAX_ORDER=${KENLM_MAX_ORDER})
-
-install(TARGETS kenlm
-  RUNTIME DESTINATION bin
-  LIBRARY DESTINATION lib
-  ARCHIVE DESTINATION lib
-)
 
 # This directory has children that need to be processed
 add_subdirectory(builder)
@@ -54,9 +48,9 @@ set(EXE_LIST
   fragment
   build_binary
   kenlm_benchmark
-)
+  )
 
-set(LM_LIBS kenlm kenlm_util ${Boost_LIBRARIES} Threads::Threads)
+set(LM_LIBS kenlm kenlm_util Threads::Threads)
 
 AddExes(EXES ${EXE_LIST}
         LIBRARIES ${LM_LIBS})

--- a/lm/builder/CMakeLists.txt
+++ b/lm/builder/CMakeLists.txt
@@ -28,12 +28,12 @@ set(KENLM_BUILDER_SOURCE
 #
 add_library(kenlm_builder ${KENLM_BUILDER_SOURCE})
 
-target_link_libraries(kenlm_builder PUBLIC kenlm kenlm_util ${Boost_LIBRARIES} Threads::Threads)
+target_link_libraries(kenlm_builder PUBLIC kenlm kenlm_util Threads::Threads)
 
 AddExes(EXES lmplz
-        LIBRARIES kenlm_builder kenlm kenlm_util ${Boost_LIBRARIES} Threads::Threads)
+        LIBRARIES kenlm_builder kenlm kenlm_util Threads::Threads)
 AddExes(EXES count_ngrams
-        LIBRARIES kenlm_builder kenlm kenlm_util ${Boost_LIBRARIES} Threads::Threads)
+        LIBRARIES kenlm_builder kenlm kenlm_util Threads::Threads)
 
 if(BUILD_TESTING)
 
@@ -44,5 +44,5 @@ if(BUILD_TESTING)
   )
 
   AddTests(TESTS ${KENLM_BOOST_TESTS_LIST}
-           LIBRARIES kenlm_builder kenlm kenlm_util ${Boost_LIBRARIES} Threads::Threads)
+           LIBRARIES kenlm_builder kenlm kenlm_util Threads::Threads)
 endif()

--- a/util/CMakeLists.txt
+++ b/util/CMakeLists.txt
@@ -80,18 +80,15 @@ endif()
 # Group these objects together for later use.
 add_library(kenlm_util ${KENLM_UTIL_DOUBLECONVERSION_SOURCE} ${KENLM_UTIL_STREAM_SOURCE} ${KENLM_UTIL_SOURCE})
 set_target_properties(kenlm_util PROPERTIES POSITION_INDEPENDENT_CODE ON)
-target_link_libraries(kenlm_util PUBLIC ${Boost_LIBRARIES} ${READ_COMPRESSED_LIBS} Threads::Threads ${RT})
-
-install(TARGETS kenlm_util
-  RUNTIME DESTINATION bin
-  LIBRARY DESTINATION lib
-  ARCHIVE DESTINATION lib
-)
-
+target_link_libraries(kenlm_util PUBLIC
+  "$<BUILD_INTERFACE:${Boost_LIBRARIES}>"
+  "$<BUILD_INTERFACE:${READ_COMPRESSED_LIBS}>"
+  $<BUILD_INTERFACE:Threads::Threads>
+  $<BUILD_INTERFACE:${RT}>)
 
 if (NOT WIN32)
 AddExes(EXES probing_hash_table_benchmark
-        LIBRARIES kenlm_util ${Boost_LIBRARIES} Threads::Threads)
+        LIBRARIES kenlm_util Threads::Threads)
 endif()
 
 # Only compile and run unit tests if tests should be run
@@ -111,10 +108,10 @@ if(BUILD_TESTING)
   )
 
   AddTests(TESTS ${KENLM_BOOST_TESTS_LIST}
-           LIBRARIES kenlm_util ${Boost_LIBRARIES} Threads::Threads)
+           LIBRARIES kenlm_util Threads::Threads)
 
   # file_piece_test requires an extra command line parameter
   KenLMAddTest(TEST file_piece_test
-               LIBRARIES kenlm_util ${Boost_LIBRARIES} Threads::Threads
+               LIBRARIES kenlm_util Threads::Threads
                TEST_ARGS ${CMAKE_CURRENT_SOURCE_DIR}/file_piece.cc)
 endif()


### PR DESCRIPTION
Creates CMake config file for KenLM i.e.
https://gitlab.kitware.com/cmake/community/-/wikis/doc/tutorials/How-to-create-a-ProjectConfig.cmake-file.
This change creates one and lets KenLM interact with modern CMake
projects without a ton of Findkenlm.cmake cruft (right now projects need
this file to interoperate with installed KenLM libs, and need to themselves
install it and pass it to their dependent projects, which is a lot of extra work).

Other improvements include:
- Remove duplicative linking of `${Boost_LIBRARIES}` and instead link
  to kenlm_util once then transitively to other targets
- Do the same for Threads::Threads
- Both of the above libraries are handled for transitive linking via
  CMake's `find_dependency(...)` in the genreated `kenlmConfig.cmake`
- Wrap libraries in `BUILD_INTERFACE` so that libraries that find KenLM
  don't transitively compile with lib and include paths that are the
  same as the machines KenLM was compiled in