### PR TITLE
CMake improvements/fixes for old versions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -111,15 +111,7 @@ if(ENABLE_PYTHON)
   add_subdirectory(python)
 endif()
 
-# Asset installation
-install(
-  TARGETS kenlm kenlm_util
-  EXPORT kenlmTargets
-  RUNTIME DESTINATION bin
-  LIBRARY DESTINATION lib
-  ARCHIVE DESTINATION lib
-)
-
+# Install targets
 install(EXPORT kenlmTargets
   FILE kenlmTargets.cmake
   NAMESPACE kenlm::

--- a/cmake/kenlmConfig.cmake.in
+++ b/cmake/kenlmConfig.cmake.in
@@ -4,8 +4,16 @@ include(CMakeFindDependencyMacro)
 
 find_dependency(Boost)
 find_dependency(Threads)
-find_dependency(ZLIB)
-find_dependency(BZip2)
-find_dependency(LibLZMA)
+
+# Compression libs
+if (@ZLIB_FOUND@)
+  find_dependency(ZLIB)
+endif()
+if (@BZIP2_FOUND@)
+  find_dependency(BZip2)
+endif()
+if (@LIBLZMA_FOUND@)
+  find_dependency(LibLZMA)
+endif()
 
 include("${CMAKE_CURRENT_LIST_DIR}/kenlmTargets.cmake")

--- a/lm/CMakeLists.txt
+++ b/lm/CMakeLists.txt
@@ -48,9 +48,17 @@ set(EXE_LIST
   fragment
   build_binary
   kenlm_benchmark
-  )
+)
 
 set(LM_LIBS kenlm kenlm_util Threads::Threads)
+
+install(
+  TARGETS kenlm
+  EXPORT kenlmTargets
+  RUNTIME DESTINATION bin
+  LIBRARY DESTINATION lib
+  ARCHIVE DESTINATION lib
+)
 
 AddExes(EXES ${EXE_LIST}
         LIBRARIES ${LM_LIBS})

--- a/lm/builder/CMakeLists.txt
+++ b/lm/builder/CMakeLists.txt
@@ -35,6 +35,14 @@ AddExes(EXES lmplz
 AddExes(EXES count_ngrams
         LIBRARIES kenlm_builder kenlm kenlm_util Threads::Threads)
 
+install(
+  TARGETS kenlm_builder
+  EXPORT kenlmTargets
+  RUNTIME DESTINATION bin
+  LIBRARY DESTINATION lib
+  ARCHIVE DESTINATION lib
+)
+      
 if(BUILD_TESTING)
 
   # Explicitly list the Boost test files to be compiled

--- a/lm/filter/CMakeLists.txt
+++ b/lm/filter/CMakeLists.txt
@@ -28,3 +28,10 @@ target_link_libraries(kenlm_filter PUBLIC kenlm_util)
 AddExes(EXES filter phrase_table_vocab
         LIBRARIES kenlm_filter kenlm)
 
+install(
+  TARGETS kenlm_filter
+  EXPORT kenlmTargets
+  RUNTIME DESTINATION bin
+  LIBRARY DESTINATION lib
+  ARCHIVE DESTINATION lib
+)

--- a/lm/interpolate/CMakeLists.txt
+++ b/lm/interpolate/CMakeLists.txt
@@ -36,6 +36,14 @@ if(ENABLE_INTERPOLATE)
   AddExes(EXES ${KENLM_INTERPOLATE_EXES}
     LIBRARIES ${KENLM_INTERPOLATE_LIBS})
 
+  install(
+    TARGETS kenlm_interpolate
+    EXPORT kenlmTargets
+    RUNTIME DESTINATION bin
+    LIBRARY DESTINATION lib
+    ARCHIVE DESTINATION lib
+  )
+  
   if(BUILD_TESTING)
     AddTests(TESTS backoff_reunification_test bounded_sequence_encoding_test merge_vocab_test normalize_test tune_derivatives_test
       LIBRARIES ${KENLM_INTERPOLATE_LIBS} Threads::Threads)

--- a/util/CMakeLists.txt
+++ b/util/CMakeLists.txt
@@ -31,26 +31,31 @@ if (WIN32)
   set(KENLM_UTIL_SOURCE ${KENLM_UTIL_SOURCE} getopt.c)
 endif()
 
+# This directory has children that need to be processed
+add_subdirectory(double-conversion)
+add_subdirectory(stream)
+
+add_library(kenlm_util ${KENLM_UTIL_DOUBLECONVERSION_SOURCE} ${KENLM_UTIL_STREAM_SOURCE} ${KENLM_UTIL_SOURCE})
+
 set(READ_COMPRESSED_FLAGS)
-set(READ_COMPRESSED_LIBS)
 find_package(ZLIB)
 if (ZLIB_FOUND)
   set(READ_COMPRESSED_FLAGS "${READ_COMPRESSED_FLAGS} -DHAVE_ZLIB")
-  set(READ_COMPRESSED_LIBS ${READ_COMPRESSED_LIBS} ${ZLIB_LIBRARIES})
+  target_link_libraries(kenlm_util PRIVATE ${ZLIB_LIBRARIES})
   include_directories(${ZLIB_INCLUDE_DIR})
 endif()
 
 find_package(BZip2)
 if (BZIP2_FOUND)
   set(READ_COMPRESSED_FLAGS "${READ_COMPRESSED_FLAGS} -DHAVE_BZLIB")
-  set(READ_COMPRESSED_LIBS ${READ_COMPRESSED_LIBS} ${BZIP2_LIBRARIES})
+    target_link_libraries(kenlm_util PRIVATE ${BZIP2_LIBRARIES})
   include_directories(${BZIP2_INCLUDE_DIR})
 endif()
 
 find_package(LibLZMA)
 if (LIBLZMA_FOUND)
   set(READ_COMPRESSED_FLAGS "${READ_COMPRESSED_FLAGS} -DHAVE_XZLIB")
-  set(READ_COMPRESSED_LIBS ${READ_COMPRESSED_LIBS} ${LIBLZMA_LIBRARIES})
+      target_link_libraries(kenlm_util PRIVATE ${LIBLZMA_LIBRARIES})
   include_directories(${LIBLZMA_INCLUDE_DIRS})
 endif()
 if (NOT "${READ_COMPRESSED_FLAGS}" STREQUAL "")
@@ -58,10 +63,6 @@ if (NOT "${READ_COMPRESSED_FLAGS}" STREQUAL "")
   set_source_files_properties(read_compressed_test.cc PROPERTIES COMPILE_FLAGS ${READ_COMPRESSED_FLAGS})
   set_source_files_properties(file_piece_test.cc PROPERTIES COMPILE_FLAGS ${READ_COMPRESSED_FLAGS})
 endif()
-
-# This directory has children that need to be processed
-add_subdirectory(double-conversion)
-add_subdirectory(stream)
 
 if(UNIX)
   include(CheckLibraryExists)
@@ -78,13 +79,22 @@ if(UNIX)
 endif()
 
 # Group these objects together for later use.
-add_library(kenlm_util ${KENLM_UTIL_DOUBLECONVERSION_SOURCE} ${KENLM_UTIL_STREAM_SOURCE} ${KENLM_UTIL_SOURCE})
 set_target_properties(kenlm_util PROPERTIES POSITION_INDEPENDENT_CODE ON)
-target_link_libraries(kenlm_util PUBLIC
+target_link_libraries(kenlm_util
+  PUBLIC
+  # Boost is required for building binaries and tests
   "$<BUILD_INTERFACE:${Boost_LIBRARIES}>"
-  "$<BUILD_INTERFACE:${READ_COMPRESSED_LIBS}>"
-  $<BUILD_INTERFACE:Threads::Threads>
-  $<BUILD_INTERFACE:${RT}>)
+  PRIVATE
+  Threads::Threads
+  ${RT})
+
+install(
+  TARGETS kenlm_util
+  EXPORT kenlmTargets
+  RUNTIME DESTINATION bin
+  LIBRARY DESTINATION lib
+  ARCHIVE DESTINATION lib
+)
 
 if (NOT WIN32)
 AddExes(EXES probing_hash_table_benchmark


### PR DESCRIPTION
Fixes https://github.com/kpu/kenlm/issues/336.

- Fix CMake going back to 3.1 -- (https://cmake.org/Bug/view.php?id=14444)
    - Moves `install` calls back to the directories where their librari
      targets are created
- Make non-transitive dependencies private (compression libs, etc) rather
   than using generator expressions
- Install auxiliary libraries (besides kenlm/kenlm_util)
- Gate compression lib deps in kenlmConfig by whether they were found at
  compile time