### PR TITLE
cnstrc_kenlm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,4 +19,7 @@ CMakeCache.txt
 CTestTestfile.cmake
 DartConfiguration.tcl
 Makefile
+
+# cnstrc ignores
 .idea/
+kenlm_bin/bin/

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ Makefile
 # cnstrc ignores
 .idea/
 kenlm_bin/bin/
+wheels/

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ CMakeCache.txt
 CTestTestfile.cmake
 DartConfiguration.tcl
 Makefile
+.idea/

--- a/build_cnstrc_wheel.sh
+++ b/build_cnstrc_wheel.sh
@@ -11,5 +11,5 @@ cd build && cmake .. && make -j 8 && cd ..
 # copy binaries into kenlm_bin dir
 cp -r build/bin kenlm_bin/
 
-# build the cnstrc_kenlm wheel
-pip wheel .
+# build the cnstrc_kenlm wheels
+pip wheel . -w wheels

--- a/build_cnstrc_wheel.sh
+++ b/build_cnstrc_wheel.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -e
+
+# re-create build dir
+rm -rf build && mkdir build
+
+# build binaries in build dir
+cd build && cmake .. && make -j 8 && cd ..
+
+# copy binaries into kenlm_bin dir
+cp -r build/bin kenlm_bin/
+
+# build the cnstrc_kenlm wheel
+pip wheel .

--- a/cnstrc_README.md
+++ b/cnstrc_README.md
@@ -1,0 +1,39 @@
+# cnstrc_kenlm
+
+This is a dedicated package to ship `kenlm` binary wheels along with binary executables
+via http://pypi.cnstrc.com.
+
+## build
+
+1. Install platform dependencies listed in [BUILDING](BUILDING).
+
+2. Build wheels:
+
+```shell
+  ./build_cnstrc_wheel.sh
+```
+
+3. Upload generated binary wheels to `s3://constructor-packages/pypi-packages/`
+
+## usage
+
+In addition to original `kenlm` package `cnstrc_kenlm` comes with a dedicated `kenlm_bin` module. 
+This is just a thin wrapper over external binary executables.
+
+```python
+import kenlm_bin
+
+# example: call 'lmplz'
+kenlm_bin.call(
+    'lmplz', ['-o', '3', '--discount_fallback', '-S', '25%'],
+    stdin=...,
+    stdout=...,
+    timeout=60,
+)
+
+# example: call 'build_binary'
+kenlm_bin.call(
+    'build_binary', ['-s', '<file_in>', '<file_out>'],
+    timeout=60,
+)
+```

--- a/kenlm_bin/__init__.py
+++ b/kenlm_bin/__init__.py
@@ -1,0 +1,5 @@
+import pkg_resources
+
+
+def p_path():
+    return pkg_resources.resource_filename

--- a/kenlm_bin/__init__.py
+++ b/kenlm_bin/__init__.py
@@ -1,3 +1,4 @@
+import os
 import pkg_resources
 import subprocess
 
@@ -6,4 +7,7 @@ from typing import List
 
 def call(executable: str, args_list: List[str], **popen_kwargs) -> int:
     executable_path = pkg_resources.resource_filename('kenlm_bin', f'bin/{executable}')
+    if not os.path.exists(executable_path):
+        raise Exception(f'Executable "{executable}" does not exist.')
+
     return subprocess.call([executable_path] + args_list, **popen_kwargs)

--- a/kenlm_bin/__init__.py
+++ b/kenlm_bin/__init__.py
@@ -1,5 +1,9 @@
 import pkg_resources
+import subprocess
+
+from typing import List
 
 
-def p_path():
-    return pkg_resources.resource_filename
+def call(executable: str, args_list: List[str], **popen_kwargs) -> int:
+    executable_path = pkg_resources.resource_filename('kenlm_bin', f'bin/{executable}')
+    return subprocess.call([executable_path] + args_list, **popen_kwargs)

--- a/setup.py
+++ b/setup.py
@@ -49,14 +49,17 @@ if compile_test('lzma.h', 'lzma'):
 ext_modules = [
     Extension(name='kenlm',
         sources=FILES + ['python/kenlm.cpp'],
-        language='C++', 
+        language='C++',
         include_dirs=['.'],
-        libraries=LIBS, 
+        libraries=LIBS,
         extra_compile_args=ARGS)
 ]
 
 setup(
-    name='kenlm',
+    name='cnstrc_kenlm',
     ext_modules=ext_modules,
     include_package_data=True,
+    verion='0.0.1',
+    packages=['kenlm_bin'],
+    package_data={'kenlm_bin': ['lmplz']}
 )

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,7 @@ setup(
     name='cnstrc_kenlm',
     ext_modules=ext_modules,
     include_package_data=True,
-    verion='0.0.1',
+    version='0.0.1',
     packages=['kenlm_bin'],
-    package_data={'kenlm_bin': ['lmplz']}
+    package_data={'kenlm_bin': ['bin/*']}
 )


### PR DESCRIPTION
This adds ability to generate `cnstrc_kenlm` binary wheels that contain binary executables. 

version `0.0.1` is already uploaded.

```
(autocomplete-3.8.5) ➜  kenlm git:(kenlm_bin) ✗ aws s3 ls s3://constructor-packages/pypi-packages/ --human | grep "cnstrc_kenlm-0.0.1"
2021-07-22 10:54:21    3.0 MiB cnstrc_kenlm-0.0.1-cp38-cp38-linux_x86_64.whl
2021-07-22 10:54:39    2.0 MiB cnstrc_kenlm-0.0.1-cp38-cp38-macosx_11_0_x86_64.whl
```

Note: `manylinux` wheels are not uploaded yet, but that shouldn't be hard if need be.
