### PR TITLE
Add vcpkg installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,18 @@ print(model.score('this is a sentence .', bos = True, eos = True))
 ```
 See [python/example.py](python/example.py) and [python/kenlm.pyx](python/kenlm.pyx) for more, including stateful APIs.  
 
+### Building kenlm - Using vcpkg
+
+You can download and install kenlm using the [vcpkg](https://github.com/Microsoft/vcpkg) dependency manager:
+
+    git clone https://github.com/Microsoft/vcpkg.git
+    cd vcpkg
+    ./bootstrap-vcpkg.sh
+    ./vcpkg integrate install
+    ./vcpkg install kenlm
+
+The kenlm port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
+
 ---
 
 The name was Hieu Hoang's idea, not mine.


### PR DESCRIPTION
kenlm is available as a port in [vcpkg](https://github.com/microsoft/vcpkg), a C++ library manager that simplifies installation for kenlm and other project dependencies. Documenting the install process here will help users get started by providing a single set of commands to build kenlm, ready to be included in their projects.

We also test whether our library ports build in various configurations (dynamic, static) on various platforms (OSX, Linux, Windows: x86, x64) to keep a wide coverage for users.

I'm a maintainer for vcpkg, and [here is what the port script looks like](https://github.com/microsoft/vcpkg/blob/master/ports/kenlm/portfile.cmake). We try to keep the library maintained as close as possible to the original library. :)