### PR TITLE
Always build a dylib when building Python bindings on macOS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ CMakeCache.txt
 CTestTestfile.cmake
 DartConfiguration.tcl
 Makefile
+*.egg-info/

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,10 @@ if platform.system() == 'Linux':
     ARGS.append('-DHAVE_CLOCKGETTIME')
 elif platform.system() == 'Darwin':
     LIBS = ['c++']
+    # Build a dylib on macOS
+    import sysconfig
+    vars = sysconfig.get_config_vars()
+    vars['LDSHARED'] = vars['LDSHARED'].replace('-bundle', '-dynamiclib')
 else:
     LIBS = []
 


### PR DESCRIPTION
Building a dylib on macOS means that the installed KenLM artifact can be used either by Python directly via `import python` or consumed by C++ libraries that want to have KenLM as a runtime dependency.

With both of these approaches, Python users can `pip install git+https://github.com/kpu/kenlm` and get a library that can be universally consumed.

Since Linux allows for linking against `.so` ELF objects, this isn't needed on Linux. Windows is similar.