### PR TITLE
Manually set include paths on macOS to find LZMA

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ FILES = [fn for fn in FILES if not (fn.endswith('main.cc') or fn.endswith('test.
 
 #We don't need -std=c++11 but python seems to be compiled with it now.  https://github.com/kpu/kenlm/issues/86
 ARGS = ['-O3', '-DNDEBUG', '-DKENLM_MAX_ORDER='+max_order, '-std=c++11']
+INCLUDE_PATHS = []
 
 if platform.system() == 'Linux':
     LIBS = ['stdc++', 'rt']
@@ -34,6 +35,7 @@ else:
 #Attempted fix to https://github.com/kpu/kenlm/issues/186 and https://github.com/kpu/kenlm/issues/197
 if platform.system() == 'Darwin':
     ARGS += ["-stdlib=libc++", "-mmacosx-version-min=10.7"]
+    INCLUDE_PATHS.append("/usr/local/include")
 
 if compile_test('zlib.h', 'z'):
     ARGS.append('-DHAVE_ZLIB')
@@ -51,7 +53,7 @@ ext_modules = [
     Extension(name='kenlm',
         sources=FILES + ['python/kenlm.cpp'],
         language='C++', 
-        include_dirs=['.'],
+        include_dirs=['.'] + INCLUDE_PATHS,
         libraries=LIBS, 
         extra_compile_args=ARGS)
 ]


### PR DESCRIPTION
For whatever reason, when KenLM is built from `pip` (e.g. `pip install git+https://github.com/kpu/kenlm.git`), `/usr/local/include` isn't getting properly propagated on some macOS systems, and the resulting build can't find `lzma.h`. The test compilation with that header works when specifically passed with `-include lzma.h`, but fails when built by the `setuptools` `Extension`.

Failure example here: https://app.circleci.com/pipelines/github/flashlight/text/283/workflows/f4d5ff8f-2201-401b-a8d7-bf207fd7e64f/jobs/2492
