### PR TITLE
Isolate binary and Boost-dependent build components

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@ project(kenlm)
 
 option(FORCE_STATIC "Build static executables" OFF)
 option(COMPILE_TESTS "Compile tests" OFF)
-option(BUILD_TOOLS "Build binary tools (filter, builder, etc). Requires Boost")
+option(BUILD_TOOLS "Build binary tools (filter, builder, etc). Requires Boost" ON)
 option(ENABLE_PYTHON "Build Python bindings" OFF)
 option(BUILD_PYTHON_STANDALONE "Build standalone C++ lib with Python install" OFF)
 # Eigen3 less than 3.1.0 has a race condition: http://eigen.tuxfamily.org/bz/show_bug.cgi?id=466

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,11 +16,14 @@ project(kenlm)
 option(FORCE_STATIC "Build static executables" OFF)
 option(COMPILE_TESTS "Compile tests" OFF)
 option(ENABLE_PYTHON "Build Python bindings" OFF)
+option(BUILD_UTIL "Build KenLM util library" ON)
 option(BUILD_PYTHON_STANDALONE "Build standalone C++ lib with Python install" OFF)
 # Eigen3 less than 3.1.0 has a race condition: http://eigen.tuxfamily.org/bz/show_bug.cgi?id=466
 find_package(Eigen3 3.1.0 CONFIG)
 include(CMakeDependentOption)
 cmake_dependent_option(ENABLE_INTERPOLATE "Build interpolation program (depends on Eigen3)" ON "EIGEN3_FOUND AND NOT WIN32" OFF)
+cmake_dependent_option(BUILD_TOOLS "Build binary tools (filter, builder, etc)" ON "BUILD_UTIL" OFF)
+cmake_dependent_option(BUILD_BENCHMARKS "Build benchmarks" ON "BUILD_UTIL AND BUILD_TOOLS" OFF)
 
 set(KENLM_MAX_ORDER 6 CACHE STRING "Maximum supported ngram order")
 
@@ -93,13 +96,18 @@ endif()
 # And our helper modules
 list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake/modules)
 
-# We need boost
-find_package(Boost 1.41.0 REQUIRED COMPONENTS
-  program_options
-  system
-  thread
-  unit_test_framework
-)
+if (BUILD_UTIL AND BUILD_TOOLS)
+  find_package(Boost 1.41.0 REQUIRED COMPONENTS
+    program_options
+    system
+    thread
+    )
+endif()
+if (BUILD_TESTING)
+  find_package(Boost 1.41.0 REQUIRED COMPONENTS
+    unit_test_framework
+    )
+endif()
 
 # Define where include files live
 include_directories(${Boost_INCLUDE_DIRS})
@@ -107,9 +115,12 @@ include_directories(${Boost_INCLUDE_DIRS})
 set(THREADS_PREFER_PTHREAD_FLAG ON)
 find_package(Threads REQUIRED)
 
+
 # Process subdirectories
-add_subdirectory(util)
 add_subdirectory(lm)
+if (BUILD_UTIL)
+  add_subdirectory(util)
+endif()
 
 if(ENABLE_PYTHON)
   add_subdirectory(python)
@@ -122,7 +133,15 @@ install(EXPORT kenlmTargets
   DESTINATION share/kenlm/cmake
 )
 
-foreach(SUBDIR IN ITEMS util util/double-conversion util/stream lm lm/builder lm/common lm/filter lm/interpolate)
+set(_headers_to_install lm lm/common)
+if (BUILD_UTIL)
+  list(APPEND _headers_to_install util util/double-conversion util/stream)
+endif()
+if (BUILD_TOOLS)
+  list(APPEND _headers_to_install lm/builder lm/filter lm/interpolate)
+endif()
+
+foreach(SUBDIR IN ITEMS ${_headers_to_install})
   file(GLOB HEADERS ${CMAKE_CURRENT_LIST_DIR}/${SUBDIR}/*.h ${CMAKE_CURRENT_LIST_DIR}/${SUBDIR}/*.hh)
   install(FILES ${HEADERS} DESTINATION include/kenlm/${SUBDIR} COMPONENT headers)
 endforeach(SUBDIR)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,15 +15,14 @@ project(kenlm)
 
 option(FORCE_STATIC "Build static executables" OFF)
 option(COMPILE_TESTS "Compile tests" OFF)
+option(BUILD_TOOLS "Build binary tools (filter, builder, etc). Requires Boost")
 option(ENABLE_PYTHON "Build Python bindings" OFF)
-option(BUILD_UTIL "Build KenLM util library" ON)
 option(BUILD_PYTHON_STANDALONE "Build standalone C++ lib with Python install" OFF)
 # Eigen3 less than 3.1.0 has a race condition: http://eigen.tuxfamily.org/bz/show_bug.cgi?id=466
 find_package(Eigen3 3.1.0 CONFIG)
 include(CMakeDependentOption)
-cmake_dependent_option(ENABLE_INTERPOLATE "Build interpolation program (depends on Eigen3)" ON "EIGEN3_FOUND AND NOT WIN32" OFF)
-cmake_dependent_option(BUILD_TOOLS "Build binary tools (filter, builder, etc)" ON "BUILD_UTIL" OFF)
-cmake_dependent_option(BUILD_BENCHMARKS "Build benchmarks" ON "BUILD_UTIL AND BUILD_TOOLS" OFF)
+cmake_dependent_option(ENABLE_INTERPOLATE "Build interpolation program (depends on Eigen3)" ON "BUILD_TOOLS AND EIGEN3_FOUND AND NOT WIN32" OFF)
+cmake_dependent_option(BUILD_BENCHMARKS "Build benchmarks" ON "BUILD_TOOLS" OFF)
 
 set(KENLM_MAX_ORDER 6 CACHE STRING "Maximum supported ngram order")
 
@@ -96,7 +95,7 @@ endif()
 # And our helper modules
 list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake/modules)
 
-if (BUILD_UTIL AND BUILD_TOOLS)
+if (BUILD_TOOLS)
   find_package(Boost 1.41.0 REQUIRED COMPONENTS
     program_options
     system
@@ -118,9 +117,7 @@ find_package(Threads REQUIRED)
 
 # Process subdirectories
 add_subdirectory(lm)
-if (BUILD_UTIL)
   add_subdirectory(util)
-endif()
 
 if(ENABLE_PYTHON)
   add_subdirectory(python)
@@ -133,12 +130,9 @@ install(EXPORT kenlmTargets
   DESTINATION share/kenlm/cmake
 )
 
-set(_headers_to_install lm lm/common)
-if (BUILD_UTIL)
-  list(APPEND _headers_to_install util util/double-conversion util/stream)
-endif()
+set(_headers_to_install lm util util/double-conversion )  
 if (BUILD_TOOLS)
-  list(APPEND _headers_to_install lm/builder lm/filter lm/interpolate)
+  list(APPEND _headers_to_install lm/builder lm/filter lm/interpolate lm/common util/stream)
 endif()
 
 foreach(SUBDIR IN ITEMS ${_headers_to_install})

--- a/cmake/kenlmConfig.cmake.in
+++ b/cmake/kenlmConfig.cmake.in
@@ -2,7 +2,9 @@
 
 include(CMakeFindDependencyMacro)
 
-find_dependency(Boost)
+if (@BUILD_UTIL@ AND @BUILD_TOOLS@)
+  find_dependency(Boost)
+endif()
 find_dependency(Threads)
 
 # Compression libs

--- a/cmake/kenlmConfig.cmake.in
+++ b/cmake/kenlmConfig.cmake.in
@@ -2,7 +2,7 @@
 
 include(CMakeFindDependencyMacro)
 
-if (@BUILD_UTIL@ AND @BUILD_TOOLS@)
+if (@BUILD_TOOLS@)
   find_dependency(Boost)
 endif()
 find_dependency(Threads)

--- a/lm/CMakeLists.txt
+++ b/lm/CMakeLists.txt
@@ -28,7 +28,7 @@ set(KENLM_LM_SOURCE
 # Given add_library(foo OBJECT ${my_foo_sources}),
 # refer to these objects as $<TARGET_OBJECTS:foo>
 #
-if (BUILD_UTIL AND BUILD_TOOLS)
+if (BUILD_TOOLS)
   # only needed if building binaries
   add_subdirectory(common)
 endif()

--- a/lm/CMakeLists.txt
+++ b/lm/CMakeLists.txt
@@ -36,9 +36,7 @@ endif()
 
 add_library(kenlm ${KENLM_LM_SOURCE} ${KENLM_LM_COMMON_SOURCE})
 set_target_properties(kenlm PROPERTIES POSITION_INDEPENDENT_CODE ON)
-if (BUILD_UTIL)
-  target_link_libraries(kenlm PUBLIC kenlm_util Threads::Threads)
-endif()
+target_link_libraries(kenlm PUBLIC kenlm_util Threads::Threads)
 # Since headers are relative to `include/kenlm` at install time, not just `include`
 target_include_directories(kenlm PUBLIC
   $<INSTALL_INTERFACE:include/kenlm>
@@ -64,10 +62,7 @@ if (BUILD_BENCHMARKS)
   list(APPEND EXE_LIST kenlm_benchmark)
 endif()
 
-set(LM_LIBS kenlm Threads::Threads)
-if (BUILD_UTIL)
-  list(APPEND LM_LIBS kenlm_util)
-endif()
+set(LM_LIBS kenlm kenlm_util Threads::Threads)
 
 install(
   TARGETS kenlm

--- a/lm/CMakeLists.txt
+++ b/lm/CMakeLists.txt
@@ -1,3 +1,4 @@
+
 # Explicitly list the source files for this subdirectory
 #
 # If you add any source files to this subdirectory
@@ -22,36 +23,51 @@ set(KENLM_LM_SOURCE
 	vocab.cc
 )
 
-
 # Group these objects together for later use.
 #
 # Given add_library(foo OBJECT ${my_foo_sources}),
 # refer to these objects as $<TARGET_OBJECTS:foo>
 #
-add_subdirectory(common)
+if (BUILD_UTIL AND BUILD_TOOLS)
+  # only needed if building binaries
+  add_subdirectory(common)
+endif()
+
 
 add_library(kenlm ${KENLM_LM_SOURCE} ${KENLM_LM_COMMON_SOURCE})
 set_target_properties(kenlm PROPERTIES POSITION_INDEPENDENT_CODE ON)
-target_link_libraries(kenlm PUBLIC kenlm_util Threads::Threads)
+if (BUILD_UTIL)
+  target_link_libraries(kenlm PUBLIC kenlm_util Threads::Threads)
+endif()
 # Since headers are relative to `include/kenlm` at install time, not just `include`
-target_include_directories(kenlm PUBLIC $<INSTALL_INTERFACE:include/kenlm>)
+target_include_directories(kenlm PUBLIC
+  $<INSTALL_INTERFACE:include/kenlm>
+  $<INSTALL_INTERFACE:include>
+)
 
 target_compile_definitions(kenlm PUBLIC -DKENLM_MAX_ORDER=${KENLM_MAX_ORDER})
 
 # This directory has children that need to be processed
-add_subdirectory(builder)
-add_subdirectory(filter)
-add_subdirectory(interpolate)
+if (BUILD_TOOLS)
+  add_subdirectory(builder)
+  add_subdirectory(filter)
+endif()
+add_subdirectory(interpolate) # gated inside by ENABLE_INTERPOLATE
 
 # Explicitly list the executable files to be compiled
 set(EXE_LIST
   query
   fragment
   build_binary
-  kenlm_benchmark
-)
+  )
+if (BUILD_BENCHMARKS)
+  list(APPEND EXE_LIST kenlm_benchmark)
+endif()
 
-set(LM_LIBS kenlm kenlm_util Threads::Threads)
+set(LM_LIBS kenlm Threads::Threads)
+if (BUILD_UTIL)
+  list(APPEND LM_LIBS kenlm_util)
+endif()
 
 install(
   TARGETS kenlm
@@ -62,11 +78,12 @@ install(
   INCLUDES DESTINATION include
 )
 
-AddExes(EXES ${EXE_LIST}
-        LIBRARIES ${LM_LIBS})
+if (BUILD_TOOLS)
+  AddExes(EXES ${EXE_LIST}
+    LIBRARIES ${LM_LIBS})
+endif()
 
 if(BUILD_TESTING)
-
   set(KENLM_BOOST_TESTS_LIST left_test partial_test)
   AddTests(TESTS ${KENLM_BOOST_TESTS_LIST}
            LIBRARIES ${LM_LIBS}

--- a/util/CMakeLists.txt
+++ b/util/CMakeLists.txt
@@ -36,7 +36,11 @@ endif()
 
 # This directory has children that need to be processed
 add_subdirectory(double-conversion)
-add_subdirectory(stream)
+
+if (BUILD_TOOLS)
+  # only required for building tools/binaries
+  add_subdirectory(stream)
+endif()
 
 add_library(kenlm_util ${KENLM_UTIL_DOUBLECONVERSION_SOURCE} ${KENLM_UTIL_STREAM_SOURCE} ${KENLM_UTIL_SOURCE})
 # Since headers are relative to `include/kenlm` at install time, not just `include`

--- a/util/CMakeLists.txt
+++ b/util/CMakeLists.txt
@@ -18,7 +18,6 @@ set(KENLM_UTIL_SOURCE
 		integer_to_string.cc
 		mmap.cc
 		murmur_hash.cc
-		parallel_read.cc
 		pool.cc
 		read_compressed.cc
 		scoped.cc
@@ -26,6 +25,10 @@ set(KENLM_UTIL_SOURCE
 		string_piece.cc
 		usage.cc
 	)
+
+if (Boost_FOUND)
+  list(APPEND KENLM_UTIL_SOURCE parallel_read.cc)
+endif()
 
 if (WIN32)
   set(KENLM_UTIL_SOURCE ${KENLM_UTIL_SOURCE} getopt.c)
@@ -83,12 +86,18 @@ endif()
 # Group these objects together for later use.
 set_target_properties(kenlm_util PROPERTIES POSITION_INDEPENDENT_CODE ON)
 target_link_libraries(kenlm_util
-  PUBLIC
-  # Boost is required for building binaries and tests
-  "$<BUILD_INTERFACE:${Boost_LIBRARIES}>"
   PRIVATE
   Threads::Threads
   ${RT})
+
+if (BUILD_TESTING OR BUILD_TOOLS AND Boost_FOUND)
+  target_link_libraries(
+    kenlm_util
+    PUBLIC
+    # Boost is required for building binaries and tests
+    "$<BUILD_INTERFACE:${Boost_LIBRARIES}>"
+    )
+endif()
 
 install(
   TARGETS kenlm_util
@@ -99,7 +108,7 @@ install(
   INCLUDES DESTINATION include
 )
 
-if (NOT WIN32)
+if (NOT WIN32 AND BUILD_BENCHMARKS)
 AddExes(EXES probing_hash_table_benchmark
         LIBRARIES kenlm_util Threads::Threads)
 endif()


### PR DESCRIPTION
Adds the `BUILD_TOOLS` (and `BUILD_BENCHMARKS`) options to the CMake build, which allows users to easily toggle building or not building binary-related components (that are also Boost-dependent). Getting a build of KenLM that doesn't depend on Boost (and thus doesn't build any binary components such as `builder` or `interpolate`) is now as simple as 
```bash
cmake .. -DBUILD_TOOLS=OFF
```
Also adds `BUILD_BENCHMARKS`, which modulates building benchmarks.

All defaults are set such that there is no behavior change from the current build if these options aren't specified.