### PR TITLE
Include functional to fix error C2039 and C2504

### DIFF
--- a/util/string_piece_hash.hh
+++ b/util/string_piece_hash.hh
@@ -1,6 +1,7 @@
 #ifndef UTIL_STRING_PIECE_HASH_H
 #define UTIL_STRING_PIECE_HASH_H
 
+#include <functional>
 #include "have.hh"
 #include "string_piece.hh"
 


### PR DESCRIPTION
Hello, I'm a member of Microsoft VCPKG, when I built this port in an internal version of Visual Studio, it failed with following errors:
```
D:\buildtrees\kenlm\src\2b1d91de6b-bf52422165.clean\util/string_piece_hash.hh(23): error C2039: 'unary_function': is not a member of 'std'
C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.35.32215\include\typeindex(25): note: see declaration of 'std'
D:\buildtrees\kenlm\src\2b1d91de6b-bf52422165.clean\util/string_piece_hash.hh(23): error C2504: 'unary_function': base class undefined
D:\buildtrees\kenlm\src\2b1d91de6b-bf52422165.clean\util/string_piece_hash.hh(23): error C2143: syntax error: missing ',' before '<'
```
The reason is new STL change, need include `<functional>` to fix them.