### PR TITLE
Explicitly try to compile with header inclusion in Python setup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ from pathlib import Path
 #Does gcc compile with this header and library?
 def compile_test(header, library):
     dummy_path = os.path.join(os.path.dirname(__file__), "dummy")
-    command = "bash -c \"g++ -include " + header + " -l" + library + " -x c++ - <<<'int main() {}' -o " + dummy_path + " >/dev/null 2>/dev/null && rm " + dummy_path + " 2>/dev/null\""
+    command = "bash -c \"g++ -include " + header + " -l" + library + " -x c++ - <<<'#include <" + header + ">\nint main() {}' -o " + dummy_path + " >/dev/null 2>/dev/null && rm " + dummy_path + " 2>/dev/null\""
     return os.system(command) == 0
 
 # Use an environment variable


### PR DESCRIPTION
There are some platforms/cases where the compiler sees a header with `-ifoo` but that `#include <foo.h>` still fails.

Without investigating these, since `#include <foo.h>` is a compile time requirement for Python bindings, change the compile test to include those headers as well.

Example of failure: https://github.com/flashlight/text/actions/runs/8039155921/job/21955863757 which succeeds from test branch when the test is added: https://github.com/flashlight/text/actions/runs/8039715499/job/21956995528 (doesn't enable `HAVE_ZLIB` falsely)