### PR TITLE
Mark fallthroughs in read_arpa.cc

### DIFF
--- a/lm/read_arpa.cc
+++ b/lm/read_arpa.cc
@@ -101,7 +101,7 @@ void ReadBackoff(util::FilePiece &in, Prob &/*weights*/) {
       break;
     case '\r':
       ConsumeNewline(in);
-      // Intentionally no break.
+      [[fallthrough]];
     case '\n':
       break;
     default:
@@ -131,6 +131,7 @@ void ReadBackoff(util::FilePiece &in, float &backoff) {
       switch (char got = in.get()) {
         case '\r':
           ConsumeNewline(in);
+	  [[fallthrough]];
         case '\n':
           break;
         default:
@@ -139,7 +140,7 @@ void ReadBackoff(util::FilePiece &in, float &backoff) {
       break;
     case '\r':
       ConsumeNewline(in);
-      // Intentionally no break.
+      [[fallthrough]];
     case '\n':
       backoff = ngram::kNoExtensionBackoff;
       break;


### PR DESCRIPTION
Allows the code to pass with LLVM/clang's `-Wimplicit-fallthrough`.

Note that one of the fallthroughs was not labeled with a comment, highlighting the utility of this flag. Could you clarify whether this one was, in fact, intentional?