### PR TITLE
Make fallthroughs explicit in murmur_hash.cc

### DIFF
--- a/util/murmur_hash.cc
+++ b/util/murmur_hash.cc
@@ -61,12 +61,12 @@ uint64_t MurmurHash64A ( const void * key, std::size_t len, uint64_t seed )
 
   switch(len & 7)
   {
-  case 7: h ^= uint64_t(data2[6]) << 48;
-  case 6: h ^= uint64_t(data2[5]) << 40;
-  case 5: h ^= uint64_t(data2[4]) << 32;
-  case 4: h ^= uint64_t(data2[3]) << 24;
-  case 3: h ^= uint64_t(data2[2]) << 16;
-  case 2: h ^= uint64_t(data2[1]) << 8;
+  case 7: h ^= uint64_t(data2[6]) << 48; [[fallthrough]];
+  case 6: h ^= uint64_t(data2[5]) << 40; [[fallthrough]];
+  case 5: h ^= uint64_t(data2[4]) << 32; [[fallthrough]];
+  case 4: h ^= uint64_t(data2[3]) << 24; [[fallthrough]];
+  case 3: h ^= uint64_t(data2[2]) << 16; [[fallthrough]];
+  case 2: h ^= uint64_t(data2[1]) << 8; [[fallthrough]];
   case 1: h ^= uint64_t(data2[0]);
           h *= m;
   };
@@ -133,8 +133,8 @@ uint64_t MurmurHash64B ( const void * key, std::size_t len, uint64_t seed )
 
   switch(len)
   {
-  case 3: h2 ^= ((unsigned char*)data)[2] << 16;
-  case 2: h2 ^= ((unsigned char*)data)[1] << 8;
+  case 3: h2 ^= ((unsigned char*)data)[2] << 16; [[fallthrough]];
+  case 2: h2 ^= ((unsigned char*)data)[1] << 8; [[fallthrough]];
   case 1: h2 ^= ((unsigned char*)data)[0];
       h2 *= m;
   };


### PR DESCRIPTION
Allows code to compile with `-Wimplicit-fallthrough`. In conjunction with #450  this is sufficient to show that all fallthroughs are explicit and, therefore, safe (in a sense).