### PR TITLE
Update CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.1)
-
+set(CMAKE_CXX_STANDARD 11)
 if (WIN32)
     set(Boost_USE_STATIC_LIBS OFF)
     # The auto-linking feature has problems with USE_STATIC_LIBS off, so we use


### PR DESCRIPTION
on macos m3 the make command files. boost throws errors.
to solve this `CMAKE_CXX_STANDARD` needs to be set in CMakeLists.txt