### PR TITLE
Fix build with cmake 4.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.10)
 
 if (WIN32)
     set(Boost_USE_STATIC_LIBS OFF)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,2 @@
 [build-system]
-requires = ["setuptools", "wheel", "cmake"]
+requires = ["setuptools", "wheel", "cmake>=3.10"]

--- a/python/BuildStandalone.cmake
+++ b/python/BuildStandalone.cmake
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.10)
 
 file(GLOB
   KENLM_PYTHON_STANDALONE_SRCS


### PR DESCRIPTION
This pull request includes updates to the minimum required CMake version across various files to ensure compatibility with newer features. The most important changes are:

Updates to CMake version requirements:

* [`CMakeLists.txt`](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aL1-R1): Updated the minimum CMake version from 3.1 to 3.10.
* [`python/BuildStandalone.cmake`](diffhunk://#diff-e095bc233e8bc7c9f9a25f31738d9718433d1440389c8dffdb1a68a9d8003fe2L1-R1): Updated the minimum CMake version from 3.1 to 3.10.

Dependency updates:

* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L2-R2): Modified the required CMake version to be at least 3.10.